### PR TITLE
Initialize Next.js smart dashboard app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# review
+# Smart Dashboard
+
+This repository contains the source for the **Smart Dashboard** project, a Next.js 14 starter application tailored for analytics and admin experiences. The application code lives inside the [`smart-dashboard`](./smart-dashboard) directory.
+
+See the project [README](./smart-dashboard/README.md) for setup and usage instructions.

--- a/smart-dashboard/.eslintrc.json
+++ b/smart-dashboard/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"],
+  "rules": {
+    "@next/next/no-html-link-for-pages": "off"
+  }
+}

--- a/smart-dashboard/.gitignore
+++ b/smart-dashboard/.gitignore
@@ -1,0 +1,27 @@
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# production
+/.next/
+/out/
+
+# misc
+.DS_Store
+*.pem
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*

--- a/smart-dashboard/README.md
+++ b/smart-dashboard/README.md
@@ -1,0 +1,42 @@
+# Smart Dashboard
+
+This project is a bootstrapped Next.js 14 application configured with TypeScript, ESLint, Tailwind CSS, and an initial landing page for a smart analytics dashboard experience.
+
+## Getting Started
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run the development server:
+
+```bash
+npm run dev
+```
+
+Then open [http://localhost:3000](http://localhost:3000) to view the dashboard starter.
+
+## Features
+
+- App Router with a Tailwind CSS powered hero and analytics overview section.
+- Example `OverviewCard` component in `src/components` demonstrating the `@/*` import alias.
+- Preconfigured ESLint and TypeScript for consistent, type-safe development.
+- Tailwind config with opinionated colors suited for dashboard UI foundations.
+
+## Deployment
+
+Create an optimized production build:
+
+```bash
+npm run build
+```
+
+Start the production server:
+
+```bash
+npm run start
+```
+
+The project is ready to deploy to platforms that support Next.js, such as Vercel or Netlify.

--- a/smart-dashboard/app/api/health/route.ts
+++ b/smart-dashboard/app/api/health/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-static";
+
+export async function GET() {
+  return NextResponse.json({ status: "ok" });
+}

--- a/smart-dashboard/app/globals.css
+++ b/smart-dashboard/app/globals.css
@@ -1,0 +1,22 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+  background-color: #0f172a;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.15), transparent 55%),
+    radial-gradient(circle at top right, rgba(14, 165, 233, 0.15), transparent 50%),
+    #020617;
+  min-height: 100vh;
+  color: #e2e8f0;
+}
+
+main {
+  min-height: 100vh;
+}

--- a/smart-dashboard/app/icon.tsx
+++ b/smart-dashboard/app/icon.tsx
@@ -1,0 +1,38 @@
+import { ImageResponse } from "next/og";
+
+export const size = {
+  width: 64,
+  height: 64
+};
+
+export const contentType = "image/png";
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: "linear-gradient(135deg, #2563EB, #0EA5E9)",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          borderRadius: 16
+        }}
+      >
+        <span
+          style={{
+            fontSize: 28,
+            fontWeight: 700,
+            color: "#F8FAFC",
+            fontFamily: "Inter"
+          }}
+        >
+          SD
+        </span>
+      </div>
+    ),
+    size
+  );
+}

--- a/smart-dashboard/app/layout.tsx
+++ b/smart-dashboard/app/layout.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import "./globals.css";
+
+const inter = Inter({ subsets: ["latin"] });
+
+export const metadata: Metadata = {
+  title: "Smart Dashboard",
+  description: "A modern analytics dashboard starter built with Next.js and Tailwind CSS.",
+  metadataBase: new URL("https://smart-dashboard.local")
+};
+
+export default function RootLayout({
+  children
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body className={`${inter.className} bg-slate-950`}>{children}</body>
+    </html>
+  );
+}

--- a/smart-dashboard/app/manifest.ts
+++ b/smart-dashboard/app/manifest.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "Smart Dashboard",
+    short_name: "Dashboard",
+    description: "Intelligent analytics dashboard starter built with Next.js",
+    start_url: "/",
+    display: "standalone",
+    background_color: "#020617",
+    theme_color: "#2563EB",
+    icons: [
+      {
+        src: "/favicon.svg",
+        sizes: "64x64",
+        type: "image/svg+xml"
+      }
+    ]
+  };
+}

--- a/smart-dashboard/app/page.tsx
+++ b/smart-dashboard/app/page.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import Link from "next/link";
+import { OverviewCard } from "@/components/OverviewCard";
+
+const features = [
+  {
+    title: "Real-time Analytics",
+    description:
+      "Connect your data sources and surface the metrics that matter with live updating widgets.",
+    icon: "📊"
+  },
+  {
+    title: "Smart Alerts",
+    description:
+      "Keep your team informed with AI-assisted anomaly detection delivered to Slack or email.",
+    icon: "🔔"
+  },
+  {
+    title: "Customizable Workspaces",
+    description:
+      "Drag-and-drop components to compose dashboards that fit every stakeholder's needs.",
+    icon: "🧩"
+  }
+];
+
+const overviewMetrics = [
+  {
+    title: "Monthly Revenue",
+    value: "$128K",
+    change: "▲ 12.4% vs last month",
+    changeType: "positive" as const
+  },
+  {
+    title: "Active Users",
+    value: "8,542",
+    change: "▲ 5.1% vs last week",
+    changeType: "positive" as const
+  },
+  {
+    title: "Churn Rate",
+    value: "2.3%",
+    change: "▼ 0.6% vs last quarter",
+    changeType: "negative" as const
+  }
+];
+
+export default function HomePage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center px-6 py-16">
+      <section className="w-full max-w-6xl rounded-3xl border border-white/10 bg-white/5 p-12 text-slate-100 shadow-xl backdrop-blur">
+        <div className="flex flex-col gap-12 lg:flex-row lg:items-center">
+          <div className="flex-1 space-y-6">
+            <span className="rounded-full bg-primary/10 px-4 py-1 text-sm font-medium text-primary">
+              Smart Dashboard Starter
+            </span>
+            <h1 className="text-4xl font-semibold leading-tight tracking-tight sm:text-5xl">
+              Build intelligent analytics experiences in minutes, not months.
+            </h1>
+            <p className="text-lg text-slate-300">
+              Kickstart your product with a Next.js + Tailwind CSS foundation that is optimized for
+              modern data teams. Ship dashboards, admin portals and reporting suites faster than ever.
+            </p>
+            <div className="flex flex-wrap gap-4">
+              <Link
+                href="https://nextjs.org/docs"
+                className="rounded-full bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90"
+              >
+                View Documentation
+              </Link>
+              <Link
+                href="https://tailwindcss.com/docs"
+                className="rounded-full border border-white/20 px-6 py-3 text-sm font-semibold text-white transition hover:border-white/60 hover:text-slate-50"
+              >
+                Tailwind Components
+              </Link>
+            </div>
+          </div>
+          <div className="flex-1 space-y-4">
+            <div className="grid gap-4 sm:grid-cols-2">
+              {features.map((feature) => (
+                <article
+                  key={feature.title}
+                  className="rounded-2xl border border-white/10 bg-slate-900/40 p-6 shadow-lg backdrop-blur"
+                >
+                  <div className="mb-4 text-3xl">{feature.icon}</div>
+                  <h2 className="text-xl font-semibold text-white">{feature.title}</h2>
+                  <p className="mt-2 text-sm text-slate-300">{feature.description}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        </div>
+        <div className="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {overviewMetrics.map((metric) => (
+            <OverviewCard key={metric.title} {...metric} />
+          ))}
+        </div>
+      </section>
+      <footer className="mt-16 text-sm text-slate-500">
+        Crafted with Next.js 14 & Tailwind CSS 3.4 for forward-thinking teams.
+      </footer>
+    </main>
+  );
+}

--- a/smart-dashboard/next-env.d.ts
+++ b/smart-dashboard/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/smart-dashboard/next.config.ts
+++ b/smart-dashboard/next.config.ts
@@ -1,0 +1,10 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+export default nextConfig;

--- a/smart-dashboard/package.json
+++ b/smart-dashboard/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "smart-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.4",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.17",
+    "@types/react": "18.2.57",
+    "@types/react-dom": "18.2.19",
+    "autoprefixer": "10.4.16",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.1.4",
+    "postcss": "8.4.35",
+    "tailwindcss": "3.4.1",
+    "typescript": "5.3.3"
+  }
+}

--- a/smart-dashboard/postcss.config.js
+++ b/smart-dashboard/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/smart-dashboard/public/favicon.svg
+++ b/smart-dashboard/public/favicon.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <defs>
+    <linearGradient id="g" x1="12" y1="12" x2="52" y2="52" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#2563EB" />
+      <stop offset="1" stop-color="#0EA5E9" />
+    </linearGradient>
+  </defs>
+  <rect x="8" y="8" width="48" height="48" rx="12" fill="url(#g)" />
+  <path
+    d="M20 38l6.5-9.5 6 7.5 5-6 6.5 8.5"
+    stroke="#F8FAFC"
+    stroke-width="4"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/smart-dashboard/src/components/OverviewCard.tsx
+++ b/smart-dashboard/src/components/OverviewCard.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+type OverviewCardProps = {
+  title: string;
+  value: string;
+  change: string;
+  changeType?: "positive" | "negative";
+};
+
+export const OverviewCard: React.FC<OverviewCardProps> = ({ title, value, change, changeType }) => {
+  const isPositive = changeType !== "negative";
+  return (
+    <div className="rounded-2xl border border-white/10 bg-slate-900/50 p-6 shadow-lg backdrop-blur">
+      <p className="text-sm font-medium text-slate-400">{title}</p>
+      <p className="mt-3 text-3xl font-semibold text-white">{value}</p>
+      <p className={`mt-2 text-sm ${isPositive ? "text-emerald-400" : "text-rose-400"}`}>{change}</p>
+    </div>
+  );
+};

--- a/smart-dashboard/src/components/index.ts
+++ b/smart-dashboard/src/components/index.ts
@@ -1,0 +1,1 @@
+export * from "./OverviewCard";

--- a/smart-dashboard/src/lib/index.ts
+++ b/smart-dashboard/src/lib/index.ts
@@ -1,0 +1,1 @@
+export * from "./utils";

--- a/smart-dashboard/src/lib/utils.ts
+++ b/smart-dashboard/src/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(" ");
+}

--- a/smart-dashboard/tailwind.config.ts
+++ b/smart-dashboard/tailwind.config.ts
@@ -1,0 +1,24 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./app/**/*.{js,ts,jsx,tsx,mdx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          DEFAULT: "#2563EB",
+          foreground: "#EFF6FF"
+        },
+        accent: "#0EA5E9"
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/smart-dashboard/tsconfig.json
+++ b/smart-dashboard/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- bootstrap a Next.js 14 project with TypeScript, ESLint, Tailwind CSS, and supporting configuration
- add an initial smart dashboard landing page, reusable overview card component, and health check API route
- document setup steps and repository structure for the new application

## Testing
- not run (dependencies not installed in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e4a457585483258168a62b4b6b3c91